### PR TITLE
Updated bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license="MIT"
 
 [build-dependencies]
 cc="1"
-bindgen="0.42"
+bindgen="^0.58"
 
 [features]
 glucose = []


### PR DESCRIPTION
I have updated the `bindgen` version to match the version of `z3-sys`. The reason is that `bindgen` links to `clang` (see https://github.com/rust-lang/cargo/issues/5237).